### PR TITLE
fix issue with single pattern passed

### DIFF
--- a/oakkeeper/cli.py
+++ b/oakkeeper/cli.py
@@ -16,7 +16,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
-@click.argument('patterns')
+@click.argument('patterns', nargs=-1)
 @click.option('--base-url',
               '-U',
               envvar='OK_BASE_URL',


### PR DESCRIPTION
For now single pattern argument is passed as string to `get_repositories` which results in wrong
logic. We iterate over letters, not patterns.

This PR fix this issue.