### PR TITLE
GitHub API update

### DIFF
--- a/oakkeeper/api.py
+++ b/oakkeeper/api.py
@@ -60,20 +60,19 @@ def get_branch_data(base_url, token, repo, branch):
     return r.json()
 
 
-def protect_branch(base_url, token, repo, branch, required_contexts):
+def protect_branch(base_url, token, repo, branch, required_contexts, strict=False, include_admins=True):
     protection_payload = {
-        'protection': {
-            'enabled': True,
-            'required_status_checks': {
-                'enforcement_level': 'everyone',
-                'contexts': required_contexts
-            }
-        }
+        'required_status_checks': {
+            'include_admins': include_admins,
+            'strict': strict,
+            'contexts': required_contexts
+        },
+        'restrictions': None
     }
-    url = base_url + '/repos/{repo}/branches/{branch}'.format(repo=repo, branch=branch)
+    url = base_url + '/repos/{repo}/branches/{branch}/protection'.format(repo=repo, branch=branch)
     headers = {'Accept': 'application/vnd.github.loki-preview+json'}
     auth = HTTPBasicAuth('token', token)
-    r = requests.patch(
+    r = requests.put(
         url,
         headers=headers,
         auth=auth,

--- a/oakkeeper/cli.py
+++ b/oakkeeper/cli.py
@@ -13,6 +13,7 @@ def print_version(ctx, param, value):
 
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+DEFAULT_GITHUB = 'https://api.github.com'
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -21,7 +22,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               '-U',
               envvar='OK_BASE_URL',
               prompt='Github API Base URL',
-              default='https://api.github.com',
+              default=DEFAULT_GITHUB,
               help='The Github API Base URL. For GHE use <GHE URL>/api/v3.')
 @click.option('--token',
               '-T',
@@ -94,7 +95,7 @@ def main(patterns, base_url, token, yes, zappr_path, pr_template_path, issue_tem
                 protect = click.confirm('Protect {repo}?'.format(repo=repo_data['full_name']))
             if protect:
                 protect_repo(base_url=base_url, token=token, repo_data=repo_data,
-                             files=files, upload_type=upload_type)
+                             files=files, upload_type=upload_type, use_preview_apis=base_url == DEFAULT_GITHUB)
 
 
 def get_repositories(base_url, token, patterns):
@@ -110,7 +111,7 @@ def get_repositories(base_url, token, patterns):
         page += 1
 
 
-def protect_repo(base_url, token, repo_data, files, upload_type):
+def protect_repo(base_url, token, repo_data, files, upload_type, use_preview_apis):
     repo_name = repo_data['full_name']
     default_branch = repo_data['default_branch']
     try:
@@ -133,7 +134,7 @@ def protect_repo(base_url, token, repo_data, files, upload_type):
                             repo_name, branch_name))
         with Action('Protecting branches for {repo}'.format(repo=repo_name)):
             api.ensure_branch_protection(base_url=base_url, token=token, repo=repo_name,
-                                         branch=default_branch)
+                                         branch=default_branch, use_preview_apis=use_preview_apis)
     except:
         # handled already by Action
         pass

--- a/tests/test_oakkeeper.py
+++ b/tests/test_oakkeeper.py
@@ -71,7 +71,7 @@ def test_happy_case():
         '--yes'
     ])
     assert 0 == result.exit_code
-    api.protect_branch.assert_called_with(GITHUB_API, TOKEN, 'foo/bar', 'release', ['zappr'])
+    api.protect_branch.assert_called_with(GITHUB_API, TOKEN, 'foo/bar', 'release', ['zappr'], False)
     api.get_branch_data.assert_called_with(GITHUB_API, TOKEN, 'foo/bar', 'release')
 
 
@@ -135,7 +135,8 @@ def test_patterns_argument():
                                              token=TOKEN,
                                              repo_data=matching,
                                              files=dict(),
-                                             upload_type='commit')
+                                             upload_type='commit',
+                                             use_preview_apis=False)
 
 
 @with_setup(setup, teardown)


### PR DESCRIPTION
There was an [update](https://developer.github.com/changes/2016-06-27-protected-branches-api-update/) to the protected branches API which will become effective eventually.

This PR uses the new API for Github.com and the old one for Github Enterprise.