### PR TITLE
Use branchname as head and correctly specify PR body

### DIFF
--- a/oakkeeper/api.py
+++ b/oakkeeper/api.py
@@ -118,7 +118,7 @@ def create_pr(base_url, token, repo, base, head, title='Add .zappr.yaml', body='
         'title': title,
         'head': head,
         'base': base,
-        'content': body
+        'body': body
     }
     r = requests.post(url, auth=auth, data=json.dumps(payload))
     r.raise_for_status()
@@ -164,4 +164,4 @@ def submit_pr(base_url, token, repo, default_branch, title, branch_name, files):
     commits = commit_files(base_url=base_url, token=token, repo=repo, files=files, branch_name=branch_name)
     last_commit = commits[-1]
     create_pr(base_url=base_url, token=token, repo=repo, title=title, base=default_branch,
-              head=last_commit['commit']['commit']['sha'])
+              head=branch_name, body='Apply Zappr specifications using Oakkeeper')

--- a/oakkeeper/api.py
+++ b/oakkeeper/api.py
@@ -161,7 +161,6 @@ def submit_pr(base_url, token, repo, default_branch, title, branch_name, files):
     commits = get_commits(base_url=base_url, token=token, repo=repo)
     head = commits[0]['sha']
     create_branch(base_url=base_url, token=token, repo=repo, branch_name=branch_name, from_sha=head)
-    commits = commit_files(base_url=base_url, token=token, repo=repo, files=files, branch_name=branch_name)
-    last_commit = commits[-1]
+    commit_files(base_url=base_url, token=token, repo=repo, files=files, branch_name=branch_name)
     create_pr(base_url=base_url, token=token, repo=repo, title=title, base=default_branch,
               head=branch_name, body='Apply Zappr specifications using Oakkeeper')


### PR DESCRIPTION
This PR fixes #21 

When specifying the PR using the commit hash, a 422 error is returned. This is addressed by changing the head to `branch_name` instead.

The PR also adds a basic message to the PR to ensure that the created PR is compliant in terms of PR body length.

I have tested this on a number of our internal repos, and was able to create the PRs as expected. I'm a bit at a loss for how to add unit tests for the GitHub API, but would be happy to add them if someone could point me in the right direction.